### PR TITLE
Make writeFile mkDir before attempting to write file

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -187,7 +187,7 @@ func getAPIs() []*API {
 		}
 	}
 	if err := json.Unmarshal(disco, &all); err != nil {
-		log.Fatalf("error decoding JSON in %s: %v", apisURL, err)
+		log.Fatalf("error decoding JSON in %s: %v", *apisURL, err)
 	}
 	if !*publicOnly && *apiToGenerate != "*" {
 		parts := strings.SplitN(*apiToGenerate, ":", 2)
@@ -238,6 +238,10 @@ func writeFile(file string, contents []byte) error {
 	existing, err := ioutil.ReadFile(file)
 	if err == nil && (bytes.Equal(existing, contents) || basicallyEqual(existing, contents)) {
 		return nil
+	}
+	outdir := filepath.Dir(file)
+	if err = os.MkdirAll(outdir, 0755); err != nil {
+		return fmt.Errorf("failed to Mkdir %s: %v", outdir, err)
 	}
 	return ioutil.WriteFile(file, contents, 0644)
 }


### PR DESCRIPTION
This allows `google-api-go-generator` to work from an empty directory containing only `api-list.json` when invoked like `google-api-go-generator -gendir=. -cache=false`. Otherwise it fails to write any of the discovery documents, which then causes code generation to fail.

Also fixes a golint warning (%s directive used for *string instead of string).